### PR TITLE
README hook name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ This project depends on the following libraries to work:
 If you are deploying the extension using UF CTS-IT's [redcap_deployment](https://github.com/ctsit/redcap_deployment) tools ([https://github.com/ctsit/redcap_deployment](https://github.com/ctsit/redcap_deployment)), you can activate these extensions with those tools as well. If you have an environment named `vagrant` the activation would look like this:
 
 ```
-fab instance:vagrant activate_hook:redcap_save_record,send_rx_trigger.php
-fab instance:vagrant activate_hook:redcap_data_entry_form_top,send_rx_data_entry_form_alter.php
+fab instance:vagrant activate_hook:redcap_save_record,send_rx_save_record_hook.php
+fab instance:vagrant activate_hook:redcap_data_entry_form,send_rx_data_entry_form_hook.php
 ```
 
 ### Option 2: Other Environments
 
-The `send_rx_trigger` and `send_rx_data_entry_form_alter` hooks are designed to be activated as `redcap_save_record` and `redcap_data_entry_form_top` hook functions, respectively. The hooks are dependent on a framework that calls _anonymous_ PHP functions such as UF CTS-IT's [Extensible REDCap Hooks](https://github.com/ctsit/extensible-redcap-hooks) ([https://github.com/ctsit/extensible-redcap-hooks](https://github.com/ctsit/extensible-redcap-hooks)). If you are not using such a framework, the hook will need to be edited by changing `return function($project_id)` to `function redcap_every_page_top($project_id)`.
+The `send_rx_save_record_hook` and `send_rx_data_entry_form_hook` hooks are designed to be activated as `redcap_save_record` and `redcap_data_entry_form` hook functions, respectively. The hooks are dependent on a framework that calls _anonymous_ PHP functions such as UF CTS-IT's [Extensible REDCap Hooks](https://github.com/ctsit/extensible-redcap-hooks) ([https://github.com/ctsit/extensible-redcap-hooks](https://github.com/ctsit/extensible-redcap-hooks)). If you are not using such a framework, the hook will need to be edited by changing `return function($project_id)` to `function redcap_every_page_top($project_id)`.
 
 ### Developer Notes
 
 When using the local test environment provided by UF CTS-IT's [redcap_deployment](https://github.com/ctsit/redcap_deployment) tools ([https://github.com/ctsit/redcap_deployment](https://github.com/ctsit/redcap_deployment)), you can use the deployment tools to configure the extension for testing in the local VM. If you clone this repo as a child of the `redcap_deployment` repo, you can activate the hook and plugin for testing from the root of the `redcap_deployment` repo like this:
 
 ```
-fab instance:vagrant test_hook:redcap_save_record/send_rx_trigger.php
-fab instance:vagrant test_hook:redcap_data_entry_form_top,send_rx/send_rx_data_entry_form_alter.php
+fab instance:vagrant test_hook:redcap_save_record,send_rx_save_record_hook.php
+fab instance:vagrant test_hook:redcap_data_entry_form,send_rx_data_entry_form_hook.php
 ```
 
 ## Configuration

--- a/send_rx_data_entry_form_hook.php
+++ b/send_rx_data_entry_form_hook.php
@@ -17,6 +17,17 @@
 				$is_pdf_generated = true;
 				send_rx_save_record_field($project_id, $event_id, $record_id, $field_name, $is_pdf_generated, $repeat_instance);
 			}
+			?>
+			<script type="text/javascript">
+				/*
+					All DOM modifications for the final instrument.
+				*/
+				document.addEventListener('DOMContentLoaded', function(){
+					var txt = '<div style="color: #666;font-size: 11px;"><span>NOTE: </span>New PDF will be generated and sent once the form is saved.</div>';
+					$(txt).insertBefore($('button[name="submit-btn-cancel"]')[0]);
+				});
+			</script>
+			<?php
 		}
 	};
 ?>

--- a/send_rx_data_entry_form_hook.php
+++ b/send_rx_data_entry_form_hook.php
@@ -10,12 +10,24 @@
    			$field_name = 'send_rx_is_pdf_updated';
    			$is_pdf_generated = $data[$field_name];
 			if(is_bool($is_pdf_generated) == false){
-				// Generate PDF
+				/*
+					Generate PDF.
+				*/
 				$sender = send_rx_get_sender($project_id, $event_id, $record, USERID);
 				$sender->generatePDFFile();
-				// Flag reset to avoid duplicate regeneration
+
 				$is_pdf_generated = true;
 				send_rx_save_record_field($project_id, $event_id, $record_id, $field_name, $is_pdf_generated, $repeat_instance);
+				?>
+				<script type="text/javascript">
+					/*
+						Success message on page load to confirm PDF generation.
+					*/
+					var app_path_images = '<?php echo APP_PATH_IMAGES ?>';
+					var successMsg = '<div class="darkgreen" style="margin:8px 0 5px;"><img src="'+app_path_images+'tick.png"> New PDF has been generated</div>';
+					$('#pdfExportDropdownDiv').parent().next().append(successMsg);
+				</script>
+				<?php
 			}
 			?>
 			<script type="text/javascript">
@@ -23,8 +35,14 @@
 					All DOM modifications for the final instrument.
 				*/
 				document.addEventListener('DOMContentLoaded', function(){
-					var txt = '<div style="color: #666;font-size: 11px;"><span>NOTE: </span>New PDF will be generated and sent once the form is saved.</div>';
-					$(txt).insertBefore($('button[name="submit-btn-cancel"]')[0]);
+					var helpTxt = '<div style="color: #666;font-size: 11px;"><span></span></div>';
+					$(helpTxt).insertBefore($('button[name="submit-btn-cancel"]')[0]);
+					if($('#send_rx_pdf-linknew')){
+						$('#send_rx_pdf-linknew').remove();
+					}
+
+					$('#submit-btn-saverecord').html('Send & Exit Form');
+					$('#submit-btn-savecontinue').html('Send & Stay');
 				});
 			</script>
 			<?php


### PR DESCRIPTION
1. Modify hook names and developer methods in README.
2. Add helper text under save buttons in last instrument to let user know that pdf will be generated and sent after form is saved.