### PR TITLE
Prescriber-related changes on prescription form

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -448,26 +448,16 @@ class ExternalModule extends AbstractExternalModule {
 
         // Checking if we are at the prescriber field's step.
         $id_field_name = 'send_rx_prescriber_id';
-        if (isset($Proj->metadata[$id_field_name]) && $_GET['page'] == $Proj->metadata[$id_field_name]['form_name']) {
-            if (empty($_POST[$id_field_name])) {
-                return;
-            }
+        $target_field_name = 'send_rx_prescriber_email';
 
-            $target_field_name = 'send_rx_prescriber_email';
-            if (!isset($Proj->metadata[$target_field_name])) {
-                return;
-            }
-
+        if (isset($Proj->metadata[$id_field_name]) && $_GET['page'] == $Proj->metadata[$id_field_name]['form_name'] && isset($Proj->metadata[$target_field_name]) && !empty($_POST[$id_field_name])) {
             $user_profile = new UserProfile($_POST[$id_field_name]);
             $data = $user_profile->getProfileData();
 
             $source_field_name = 'send_rx_user_email';
-            if (empty($data[$source_field_name])) {
-                return;
+            if (!empty($data[$source_field_name])) {
+                send_rx_save_record_field($project_id, $event_id, $record, $target_field_name, $data[$source_field_name]);
             }
-
-            send_rx_save_record_field($project_id, $event_id, $record, $target_field_name, $data[$source_field_name]);
-            return;
         }
 
         // Checking if PDF file exists.

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -155,7 +155,7 @@ class ExternalModule extends AbstractExternalModule {
         $prescriber_field = 'send_rx_prescriber_id';
         $data = REDCap::getData($project_id, 'array', $record, $prescriber_field, $event_id);
         $settings = array(
-            'prescriberIsSet' => !empty($data[$record][$event_id][$prescriber_field]),
+            'currentUserIsPrescriber' => $data[$record][$event_id][$prescriber_field] == USERID,
             'instrument' => $instrument,
             'table' => $table,
         );
@@ -482,8 +482,14 @@ class ExternalModule extends AbstractExternalModule {
 
         // Checking if we are on PDF form step.
         if ($Proj->metadata['send_rx_pdf']['form_name'] == $instrument) {
-            // Send prescription.
-            $sender->send(false);
+            $data = $sender->getPrescriberData();
+
+            // Only the prescriber can send the prescription.
+            if ($data['send_rx_user_id'] == USERID) {
+                // Send prescription.
+                $sender->send(false);
+            }
+
             return;
         }
 

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -446,6 +446,30 @@ class ExternalModule extends AbstractExternalModule {
             return;
         }
 
+        // Checking if we are at the prescriber field's step.
+        $id_field_name = 'send_rx_prescriber_id';
+        if (isset($Proj->metadata[$id_field_name]) && $_GET['page'] == $Proj->metadata[$id_field_name]['form_name']) {
+            if (empty($_POST[$id_field_name])) {
+                return;
+            }
+
+            $target_field_name = 'send_rx_prescriber_email';
+            if (!isset($Proj->metadata[$target_field_name])) {
+                return;
+            }
+
+            $user_profile = new UserProfile($_POST[$id_field_name]);
+            $data = $user_profile->getProfileData();
+
+            $source_field_name = 'send_rx_user_email';
+            if (empty($data[$source_field_name])) {
+                return;
+            }
+
+            send_rx_save_record_field($project_id, $event_id, $record, $target_field_name, $data[$source_field_name]);
+            return;
+        }
+
         // Checking if PDF file exists.
         if (!isset($Proj->metadata['send_rx_pdf'])) {
             return;

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -450,7 +450,7 @@ class ExternalModule extends AbstractExternalModule {
         $id_field_name = 'send_rx_prescriber_id';
         $target_field_name = 'send_rx_prescriber_email';
 
-        if (isset($Proj->metadata[$id_field_name]) && $_GET['page'] == $Proj->metadata[$id_field_name]['form_name'] && isset($Proj->metadata[$target_field_name]) && !empty($_POST[$id_field_name])) {
+        if (isset($Proj->metadata[$id_field_name]) && $instrument == $Proj->metadata[$id_field_name]['form_name'] && isset($Proj->metadata[$target_field_name]) && !empty($_POST[$id_field_name])) {
             $user_profile = new UserProfile($_POST[$id_field_name]);
             $data = $user_profile->getProfileData();
 

--- a/js/send-form.js
+++ b/js/send-form.js
@@ -22,9 +22,10 @@ document.addEventListener('DOMContentLoaded', function() {
     var $submitButtons = $('button[id^="submit-btn-"]');
     $submitButtons.addClass('btn-success');
 
-    if (!settings.prescriberIsSet) {
+    if (!settings.currentUserIsPrescriber) {
         // Disable submit buttons if prescriber is not set.
         $submitButtons.prop('disabled', true);
-        $submitButtons.prop('title', 'Your must setup a prescriber before sending your prescription.');
+        $submitButtons.removeAttr('onclick');
+        $submitButtons.prop('title', 'Only the prescriber can send the prescription.');
     }
 });


### PR DESCRIPTION
This PR provides a code that:
1. automatically saves a prescriber email into a designated field when Prescriber ID field is saved
2. restricts prescription send operation to the prescriber only

Review steps (item 1):
- [x] Make sure your User Profile project contains a field called `send_rx_user_email` and all your entries have values assign to it
- [x] Go to Patient project, access Online Designer and create a field called `send_rx_prescriber_email` in the same instrument as `send_rx_prescriber_id` (leave it as visible and non-required for testing purposes)
- [ ] Access any existing record, go to prescriber instrument and save form
- [ ] Go back to prescriber instrument and make sure `send_rx_prescriber_email` contains prescriber email

Review steps (item 2):
- [ ] On Patient side, as the assigned prescriber of a given record, go to Review & Send step and make sure you are able to send prescription (i.e. the submit buttons are active)
- [ ] Make sure any other user is not able to send prescriptions (e.g. different prescribers, study coordinators, etc)