### PR TITLE
Remove "Save changes and leave" button on Review & Send form

### DIFF
--- a/js/send-form.js
+++ b/js/send-form.js
@@ -28,4 +28,21 @@ document.addEventListener('DOMContentLoaded', function() {
         $submitButtons.removeAttr('onclick');
         $submitButtons.prop('title', 'Only the prescriber can send the prescription.');
     }
+
+    $('#stayOnPageReminderDialog').on('dialogopen', function(event, ui) {
+        // Overriding dialog message.
+        $(this).html('Are you sure you wish to leave this page?');
+
+        var buttons = $(this).dialog('option', 'buttons');
+        $.each(buttons, function(i, button) {
+            if (button.text === 'Save changes and leave') {
+                // Since "saving" makes no sense on this page, let's remove
+                // "Save changes and leave" button.
+                buttons.splice(i, 1);
+                return false;
+            }
+        });
+
+        $(this).dialog('option', 'buttons', buttons);
+    });
 });


### PR DESCRIPTION
Review steps:
- [x] Go to Review & Send Rx page
- [x] Change form status (Complete, Incomplete, etc) and click on a bullet (at the left menu) in order to leave the page
- [x] Once the warning modal shows up, make sure you do not see a "Save changes and leave" button
