### PR TITLE
Feature/add hl7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,15 @@ Send Rx requires user authentication method to work, so if your REDCap does not 
 ## Customizing PDF and email messages
 
 The presented example can be fully adapted to your needs. You may freely create your own PDF template, change the email contents configuration, and override all forms/instruments (as soon as the fields containing `send_rx_` prefix remain untouched). All form fields you update/create will available to be used as wildcards on PDF and email (e.g. `[patient][first_name]`, `[site][send_rx_name]`, `[prescriber][first_name]`, etc).
+
+## Optional HL7 functionality
+
+This module also supports sending HL7 messages. This feature is only functional
+when there is an external end-point that can convert JSON into hl7 and forward
+that hl7 to a healthcare system. To enable this feature go to the send_rx module
+configuration menu on a Sites project. Inside the end-point field enter a url
+that will accept JSON messages and convert them to HL7. Then enter in JSON message
+for the module to send to this end-point in the HL7 json message field. Finally, go
+to a Site record in your Sites project and enable sending HL7 messages. After this
+point whenever a prescriber hits the Send button for a patient in that site the JSON
+provided earlier will be sent to that end-point.

--- a/config.json
+++ b/config.json
@@ -111,28 +111,24 @@
             ]
         },
         {
-          "key" : "send-rx-hl7-settings",
-          "name" : "hl7 settings",
+          "key": "hl7-settings",
+          "name": "HL7 settings",
+          "type": "descriptive"
+        },
+        {
+          "key": "send-rx-hl7-end-point",
+          "name": "End-point",
           "required": false,
-          "type": "sub_settings",
-          "sub_settings": [
-            {
-              "key": "send-rx-hl7-end-point",
-              "name": "End-point",
-              "required": false,
-              "type": "text"
-            }, {
-              "key": "send-rx-hl7-channel-ID",
-              "name": "Channel ID",
-              "required": false,
-              "type": "text"
-            }, {
-              "key": "send-rx-hl7-json",
-              "name": "HL7 json message",
-              "required": false,
-              "type": "textarea"
-            }
-          ]
+          "type": "text"
+        }, {
+          "key": "send-rx-hl7-channel-id",
+          "name": "Channel ID",
+          "required": false,
+          "type": "text"
+        }, {
+          "key": "send-rx-hl7-json",
+          "name": "HL7 json message",
+          "type": "textarea"
         }
     ],
     "enable-every-page-hooks-on-system-pages": true,

--- a/config.json
+++ b/config.json
@@ -121,7 +121,7 @@
           "required": false,
           "type": "text"
         }, {
-          "key": "send-rx-hl7-channel-id",
+          "key": "send-rx-hl7-extension",
           "name": "Channel ID",
           "required": false,
           "type": "text"

--- a/config.json
+++ b/config.json
@@ -122,7 +122,7 @@
           "type": "text"
         }, {
           "key": "send-rx-hl7-extension",
-          "name": "Channel ID",
+          "name": "end-point extension",
           "required": false,
           "type": "text"
         }, {

--- a/config.json
+++ b/config.json
@@ -111,7 +111,7 @@
             ]
         },
         {
-          "key": "hl7-settings",
+          "key": "send-rx-hl7-settings",
           "name": "HL7 settings",
           "type": "descriptive"
         },

--- a/config.json
+++ b/config.json
@@ -121,11 +121,6 @@
           "required": false,
           "type": "text"
         }, {
-          "key": "send-rx-hl7-extension",
-          "name": "end-point extension",
-          "required": false,
-          "type": "text"
-        }, {
           "key": "send-rx-hl7-json",
           "name": "HL7 json message",
           "type": "textarea"

--- a/config.json
+++ b/config.json
@@ -109,6 +109,30 @@
                     "type": "rich-text"
                 }
             ]
+        },
+        {
+          "key" : "send-rx-hl7-settings",
+          "name" : "hl7 settings",
+          "required": false,
+          "type": "sub_settings",
+          "sub_settings": [
+            {
+              "key": "send-rx-hl7-end-point",
+              "name": "End-point",
+              "required": false,
+              "type": "text"
+            }, {
+              "key": "send-rx-hl7-channel-ID",
+              "name": "Channel ID",
+              "required": false,
+              "type": "text"
+            }, {
+              "key": "send-rx-hl7-json",
+              "name": "HL7 json message",
+              "required": false,
+              "type": "textarea"
+            }
+          ]
         }
     ],
     "enable-every-page-hooks-on-system-pages": true,

--- a/css/config.css
+++ b/css/config.css
@@ -5,6 +5,6 @@
 .send-rx [field="send-rx-message"],
 .send-rx [field="send-rx-message-subject"],
 .send-rx [field="send-rx-message-body"],
-.send-rx [field="send-rx-hl7-schema"] {
+.send-rx [field^="send-rx-hl7-"] {
     display: none;
 }

--- a/css/config.css
+++ b/css/config.css
@@ -1,10 +1,5 @@
-.send-rx [field="send-rx-pdf-template"],
-.send-rx [field="send-rx-pdf-template-variable"],
-.send-rx [field="send-rx-pdf-template-variable-key"],
-.send-rx [field="send-rx-pdf-template-variable-value"],
-.send-rx [field="send-rx-message"],
-.send-rx [field="send-rx-message-subject"],
-.send-rx [field="send-rx-message-body"],
-.send-rx [field^="send-rx-hl7-"] {
+.send-rx [field^="send-rx-pdf-template"],
+.send-rx [field^="send-rx-message"],
+.send-rx [field^="send-rx-hl7"] {
     display: none;
 }

--- a/includes/RxSender.php
+++ b/includes/RxSender.php
@@ -390,7 +390,7 @@ class RxSender {
                     //send json of hl7 message to mirth-connect
                     $settings = getHL7Settings($this->siteProjectId);
                     $client = send_rx_generate_mirth_client($settings['send-rx-hl7-end-point']);
-                    $response = $client->request('POST', $settings['send-rx-hl7-channel-ID'], $settings['send-rx-hl7-json']);
+                    $response = $client->request('POST', $settings['send-rx-hl7-extension'], $settings['send-rx-hl7-json']);
 
                     //log hl7 message that was sent
                     $success = $response->getStatusCode() == 200;

--- a/includes/RxSender.php
+++ b/includes/RxSender.php
@@ -387,9 +387,14 @@ class RxSender {
                     break;
 
                 case 'hl7':
+                    //send json of hl7 message to mirth-connect
                     $settings = getHL7Settings($this->siteProjectId);
                     $client = send_rx_generate_mirth_client($settings['send-rx-hl7-end-point']);
-                    $client->request('POST', $settings['send-rx-hl7-channel-ID'], $settings['send-rx-hl7-json']);
+                    $response = $client->request('POST', $settings['send-rx-hl7-channel-ID'], $settings['send-rx-hl7-json']);
+
+                    //log hl7 message that was sent
+                    $success = $response->getStatusCode() == 200;
+                    $this->log($type, $success, $settings['send-rx-hl7-end-point'], 'POST', $settings['send-rx-hl7-json']);
                     break;
             }
         }

--- a/includes/RxSender.php
+++ b/includes/RxSender.php
@@ -387,7 +387,9 @@ class RxSender {
                     break;
 
                 case 'hl7':
-                    // TODO: handle HL7 messages.
+                    $settings = getHL7Settings($this->siteProjectId);
+                    $client = send_rx_generate_mirth_client($settings['send-rx-hl7-end-point']);
+                    $client->request('POST', $settings['send-rx-hl7-channel-ID'], $settings['send-rx-hl7-json']);
                     break;
             }
         }

--- a/includes/RxSender.php
+++ b/includes/RxSender.php
@@ -390,7 +390,7 @@ class RxSender {
                     //send json of hl7 message to mirth-connect
                     $settings = getHL7Settings($this->siteProjectId);
                     $client = send_rx_generate_mirth_client($settings['send-rx-hl7-end-point']);
-                    $response = $client->request('POST', $settings['send-rx-hl7-extension'], $settings['send-rx-hl7-json']);
+                    $response = $client->request('POST', '', $settings['send-rx-hl7-json']);
 
                     //log hl7 message that was sent
                     $success = $response->getStatusCode() == 200;

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -88,11 +88,11 @@ function send_rx_get_project_config($project_id, $project_type) {
  * @return associative array $hl7_settings.
  *   An associative array that carries the hl7 settings with the following keys:
  *    - send-rx-hl7-end-point: the begining of the URL of the mirth connect server.
- *    - send-rx-hl7-channel-ID: extension that holds the input connector at the end-point.
+ *    - send-rx-hl7-extension: extension that holds the input connector at the end-point.
  *    - send-rx-hl7-json: json message to be sent to end-point.
  */
  function getHL7Settings($project_id) {
-   $q = ExternalModules::getSettings('send_rx', $project_id, ['send-rx-hl7-end-point', 'send-rx-hl7-channel-ID', 'send-rx-hl7-json']);
+   $q = ExternalModules::getSettings('send_rx', $project_id, ['send-rx-hl7-end-point', 'send-rx-hl7-extension', 'send-rx-hl7-json']);
    if (!db_num_rows($q)) {
        return false;
    }

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -181,7 +181,7 @@ function send_rx_piping($subject, $data) {
 
 
 /**
- * Generates a mirth client.
+ * Generates a mirth client bound to the given endpoint.
  *
  * @param string $endpoint.
  *   Base url of the REST API being connected to.

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -88,11 +88,10 @@ function send_rx_get_project_config($project_id, $project_type) {
  * @return associative array $hl7_settings.
  *   An associative array that carries the hl7 settings with the following keys:
  *    - send-rx-hl7-end-point: the begining of the URL of the mirth connect server.
- *    - send-rx-hl7-extension: extension that holds the input connector at the end-point.
  *    - send-rx-hl7-json: json message to be sent to end-point.
  */
  function getHL7Settings($project_id) {
-   $q = ExternalModules::getSettings('send_rx', $project_id, ['send-rx-hl7-end-point', 'send-rx-hl7-extension', 'send-rx-hl7-json']);
+   $q = ExternalModules::getSettings('send_rx', $project_id, ['send-rx-hl7-end-point', 'send-rx-hl7-json']);
    if (!db_num_rows($q)) {
        return false;
    }

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -179,6 +179,21 @@ function send_rx_piping($subject, $data) {
     return $subject;
 }
 
+
+/**
+ * Generates a mirth client.
+ *
+ * @param string $endpoint.
+ *   Base url of the REST API being connected to.
+ *
+ * @return REDCapMithClient obj
+ *   TRUE if success, FALSE otherwise.
+ */
+function send_rx_generate_mirth_client($endpoint) {
+  $client_module = ExternalModules::getModuleInstance('redcap_mirth_client', 'v1.0');
+  return $client_module->getClient($endpoint);
+}
+
 /**
  * Generates a PDF file.
  *

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -80,6 +80,34 @@ function send_rx_get_project_config($project_id, $project_type) {
 }
 
 /**
+ * Gets hl7 settings for that specific
+ *
+ * @param int $project_id.
+ *   The project id.
+ *
+ * @return associative array $hl7_settings.
+ *   An associative array that carries the hl7 settings with the following keys:
+ *    - send-rx-hl7-end-point: the begining of the URL of the mirth connect server.
+ *    - send-rx-hl7-channel-ID: extension that holds the input connector at the end-point.
+ *    - send-rx-hl7-json: json message to be sent to end-point.
+ */
+ function getHL7Settings($project_id) {
+   $q = ExternalModules::getSettings('send_rx', $project_id, ['send-rx-hl7-end-point', 'send-rx-hl7-channel-ID', 'send-rx-hl7-json']);
+   if (!db_num_rows($q)) {
+       return false;
+   }
+
+   $hl7_settings = [];
+
+   while($result = db_fetch_assoc($q)) {
+     $hl7_settings[$result['key']] = $result['value'];
+   }
+
+   return $hl7_settings;
+ }
+
+
+/**
  * Gets site ID from DAG.
  *
  * @param int $project_id.

--- a/samples/SendRxSites.xml
+++ b/samples/SendRxSites.xml
@@ -43,13 +43,13 @@
 	</ItemGroupDef>
 	<ItemGroupDef OID="site_information.send_rx_delivery_methods___email" Name="" Repeating="No">
 		<ItemRef ItemOID="send_rx_delivery_methods___email" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
-		<ItemRef ItemOID="send_rx_delivery_methods___h17" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
+		<ItemRef ItemOID="send_rx_delivery_methods___hl7" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
 		<ItemRef ItemOID="send_rx_delivery_methods___message_gateway" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
 		<ItemRef ItemOID="send_rx_delivery_methods___email" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
-		<ItemRef ItemOID="send_rx_delivery_methods___h17" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
+		<ItemRef ItemOID="send_rx_delivery_methods___hl7" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
 		<ItemRef ItemOID="send_rx_delivery_methods___message_gateway" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
 		<ItemRef ItemOID="send_rx_delivery_methods___email" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
-		<ItemRef ItemOID="send_rx_delivery_methods___h17" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
+		<ItemRef ItemOID="send_rx_delivery_methods___hl7" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
 		<ItemRef ItemOID="send_rx_delivery_methods___message_gateway" Mandatory="Yes" redcap:Variable="send_rx_delivery_methods"/>
 		<ItemRef ItemOID="send_rx_email_recipients" Mandatory="Yes" redcap:Variable="send_rx_email_recipients"/>
 		<ItemRef ItemOID="send_rx_email_subject" Mandatory="No" redcap:Variable="send_rx_email_subject"/>
@@ -87,9 +87,9 @@
 		<Question><TranslatedText>Delivery Methods</TranslatedText></Question>
 		<CodeListRef CodeListOID="send_rx_delivery_methods___email.choices"/>
 	</ItemDef>
-	<ItemDef OID="send_rx_delivery_methods___h17" Name="send_rx_delivery_methods___h17" DataType="boolean" Length="1" redcap:Variable="send_rx_delivery_methods" redcap:FieldType="checkbox" redcap:FieldNote="By what means will prescriptions be delivered to this site&#039;s pharmacy?" redcap:RequiredField="y" redcap:FieldAnnotation="@DEFAULT=&#039;email&#039;">
+	<ItemDef OID="send_rx_delivery_methods___hl7" Name="send_rx_delivery_methods___hl7" DataType="boolean" Length="1" redcap:Variable="send_rx_delivery_methods" redcap:FieldType="checkbox" redcap:FieldNote="By what means will prescriptions be delivered to this site&#039;s pharmacy?" redcap:RequiredField="y" redcap:FieldAnnotation="@DEFAULT=&#039;email&#039;">
 		<Question><TranslatedText>Delivery Methods</TranslatedText></Question>
-		<CodeListRef CodeListOID="send_rx_delivery_methods___h17.choices"/>
+		<CodeListRef CodeListOID="send_rx_delivery_methods___hl7.choices"/>
 	</ItemDef>
 	<ItemDef OID="send_rx_delivery_methods___message_gateway" Name="send_rx_delivery_methods___message_gateway" DataType="boolean" Length="1" redcap:Variable="send_rx_delivery_methods" redcap:FieldType="checkbox" redcap:FieldNote="By what means will prescriptions be delivered to this site&#039;s pharmacy?" redcap:RequiredField="y" redcap:FieldAnnotation="@DEFAULT=&#039;email&#039;">
 		<Question><TranslatedText>Delivery Methods</TranslatedText></Question>
@@ -99,9 +99,9 @@
 		<Question><TranslatedText>Delivery Methods</TranslatedText></Question>
 		<CodeListRef CodeListOID="send_rx_delivery_methods___email.choices"/>
 	</ItemDef>
-	<ItemDef OID="send_rx_delivery_methods___h17" Name="send_rx_delivery_methods___h17" DataType="boolean" Length="1" redcap:Variable="send_rx_delivery_methods" redcap:FieldType="checkbox" redcap:FieldNote="By what means will prescriptions be delivered to this site&#039;s pharmacy?" redcap:RequiredField="y" redcap:FieldAnnotation="@DEFAULT=&#039;email&#039;">
+	<ItemDef OID="send_rx_delivery_methods___hl7" Name="send_rx_delivery_methods___hl7" DataType="boolean" Length="1" redcap:Variable="send_rx_delivery_methods" redcap:FieldType="checkbox" redcap:FieldNote="By what means will prescriptions be delivered to this site&#039;s pharmacy?" redcap:RequiredField="y" redcap:FieldAnnotation="@DEFAULT=&#039;email&#039;">
 		<Question><TranslatedText>Delivery Methods</TranslatedText></Question>
-		<CodeListRef CodeListOID="send_rx_delivery_methods___h17.choices"/>
+		<CodeListRef CodeListOID="send_rx_delivery_methods___hl7.choices"/>
 	</ItemDef>
 	<ItemDef OID="send_rx_delivery_methods___message_gateway" Name="send_rx_delivery_methods___message_gateway" DataType="boolean" Length="1" redcap:Variable="send_rx_delivery_methods" redcap:FieldType="checkbox" redcap:FieldNote="By what means will prescriptions be delivered to this site&#039;s pharmacy?" redcap:RequiredField="y" redcap:FieldAnnotation="@DEFAULT=&#039;email&#039;">
 		<Question><TranslatedText>Delivery Methods</TranslatedText></Question>
@@ -111,9 +111,9 @@
 		<Question><TranslatedText>Delivery Methods</TranslatedText></Question>
 		<CodeListRef CodeListOID="send_rx_delivery_methods___email.choices"/>
 	</ItemDef>
-	<ItemDef OID="send_rx_delivery_methods___h17" Name="send_rx_delivery_methods___h17" DataType="boolean" Length="1" redcap:Variable="send_rx_delivery_methods" redcap:FieldType="checkbox" redcap:FieldNote="By what means will prescriptions be delivered to this site&#039;s pharmacy?" redcap:RequiredField="y" redcap:FieldAnnotation="@DEFAULT=&#039;email&#039;">
+	<ItemDef OID="send_rx_delivery_methods___hl7" Name="send_rx_delivery_methods___hl7" DataType="boolean" Length="1" redcap:Variable="send_rx_delivery_methods" redcap:FieldType="checkbox" redcap:FieldNote="By what means will prescriptions be delivered to this site&#039;s pharmacy?" redcap:RequiredField="y" redcap:FieldAnnotation="@DEFAULT=&#039;email&#039;">
 		<Question><TranslatedText>Delivery Methods</TranslatedText></Question>
-		<CodeListRef CodeListOID="send_rx_delivery_methods___h17.choices"/>
+		<CodeListRef CodeListOID="send_rx_delivery_methods___hl7.choices"/>
 	</ItemDef>
 	<ItemDef OID="send_rx_delivery_methods___message_gateway" Name="send_rx_delivery_methods___message_gateway" DataType="boolean" Length="1" redcap:Variable="send_rx_delivery_methods" redcap:FieldType="checkbox" redcap:FieldNote="By what means will prescriptions be delivered to this site&#039;s pharmacy?" redcap:RequiredField="y" redcap:FieldAnnotation="@DEFAULT=&#039;email&#039;">
 		<Question><TranslatedText>Delivery Methods</TranslatedText></Question>
@@ -149,39 +149,39 @@
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Unverified</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="2"><Decode><TranslatedText>Complete</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="send_rx_delivery_methods___email.choices" Name="send_rx_delivery_methods___email" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|h17, H17|message_gateway, Message Gateway">
+	<CodeList OID="send_rx_delivery_methods___email.choices" Name="send_rx_delivery_methods___email" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|hl7, hl7|message_gateway, Message Gateway">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="send_rx_delivery_methods___h17.choices" Name="send_rx_delivery_methods___h17" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|h17, H17|message_gateway, Message Gateway">
+	<CodeList OID="send_rx_delivery_methods___hl7.choices" Name="send_rx_delivery_methods___hl7" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|hl7, hl7|message_gateway, Message Gateway">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="send_rx_delivery_methods___message_gateway.choices" Name="send_rx_delivery_methods___message_gateway" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|h17, H17|message_gateway, Message Gateway">
+	<CodeList OID="send_rx_delivery_methods___message_gateway.choices" Name="send_rx_delivery_methods___message_gateway" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|hl7, hl7|message_gateway, Message Gateway">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="send_rx_delivery_methods___email.choices" Name="send_rx_delivery_methods___email" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|h17, H17|message_gateway, Message Gateway">
+	<CodeList OID="send_rx_delivery_methods___email.choices" Name="send_rx_delivery_methods___email" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|hl7, hl7|message_gateway, Message Gateway">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="send_rx_delivery_methods___h17.choices" Name="send_rx_delivery_methods___h17" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|h17, H17|message_gateway, Message Gateway">
+	<CodeList OID="send_rx_delivery_methods___hl7.choices" Name="send_rx_delivery_methods___hl7" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|hl7, hl7|message_gateway, Message Gateway">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="send_rx_delivery_methods___message_gateway.choices" Name="send_rx_delivery_methods___message_gateway" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|h17, H17|message_gateway, Message Gateway">
+	<CodeList OID="send_rx_delivery_methods___message_gateway.choices" Name="send_rx_delivery_methods___message_gateway" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|hl7, hl7|message_gateway, Message Gateway">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="send_rx_delivery_methods___email.choices" Name="send_rx_delivery_methods___email" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|h17, H17|message_gateway, Message Gateway">
+	<CodeList OID="send_rx_delivery_methods___email.choices" Name="send_rx_delivery_methods___email" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|hl7, hl7|message_gateway, Message Gateway">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="send_rx_delivery_methods___h17.choices" Name="send_rx_delivery_methods___h17" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|h17, H17|message_gateway, Message Gateway">
+	<CodeList OID="send_rx_delivery_methods___hl7.choices" Name="send_rx_delivery_methods___hl7" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|hl7, hl7|message_gateway, Message Gateway">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>
-	<CodeList OID="send_rx_delivery_methods___message_gateway.choices" Name="send_rx_delivery_methods___message_gateway" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|h17, H17|message_gateway, Message Gateway">
+	<CodeList OID="send_rx_delivery_methods___message_gateway.choices" Name="send_rx_delivery_methods___message_gateway" DataType="boolean" redcap:Variable="send_rx_delivery_methods" redcap:CheckboxChoices="email, Email|hl7, hl7|message_gateway, Message Gateway">
 		<CodeListItem CodedValue="1"><Decode><TranslatedText>Checked</TranslatedText></Decode></CodeListItem>
 		<CodeListItem CodedValue="0"><Decode><TranslatedText>Unchecked</TranslatedText></Decode></CodeListItem>
 	</CodeList>


### PR DESCRIPTION
This pull request provides an initial version of the redcap_mirth_client. Its fairly involved so feel free to contact me if you have any issues.

## Creating a test environment:

### Install and setup Mirth Connect:
- [ ] Install [mirth-connect-channel-examples](https://github.com/marlycormar/mirth-connect-channel-examples).
- [ ] Setup the json_to_hl7_dest_channel_writer channel found in mirth-connect-channel-examples.
- [ ] Setup the HL7 to MySQL database channel found in mirth-connect-channel-examples.
- [ ] Inside the Mirth Connect Administrator go to **channels**. Copy the channel ID of the HL7 to MySQL database channel. Then go to **channels > json_to_hl7_dest_channel_writer > Destinations**. Paste the HL7 to MySQL database channel ID into the **Channel ID field** under the **Channel Writer Settings** heading.
- [ ] Inside the Mirth Connect Administrator go to  **channels > json_to_hl7_dest_channel_writer > Source**.  Under the **Source Settings** heading set the **Response** field to **Auto-generate (Before Processing)**.

### Install and configure the needed REDCap modules
- [ ] Install and set up send_rx. Follow the instructions in the README. Please make sure you use the sites project provided in this pull request. Otherwise this module may not work.
- [ ] Install the [redcap_mirth_client](https://github.com/ctsit/redcap_mirth_client) module.
- [ ] Enable the redcap_mirth_client on your SendRxPatients project.
- [ ] Find the IP address of your Mirth Connect Server as perceived by your VM. To find that IP address ssh into your REDCap VM and run `netstat -rn`. The only valid Gateway address is the IP address you need. 
- [ ] Find the internal Mirth Connect Channel ID your send_rx project needs to talk to. This should be the ID of the json_to_hl7_dest_channel_writer you set up earlier.
- [ ] Inside the SendRxSites project, go to the send_rx module configuration menu. Inside the hl7 end-point field enter the following address: <Mirth Connect IP found earlier>:8002/api/channels/<json_to_hl7 dest_channel_writer channel id>/messages. 
- [ ] While on the configuration menu enter a json into the 'HL7 json message' field.  You can find a sample json payload inside **mirth-connect-channel-examples > channels > json_template.json**.

## Review steps:
- [ ] On a new or existing Site within the SendRxSites project, enable hl7 as a delivery method.
- [ ] Re-login as a prescriber and go to a patient you are able to send prescriptions for. Click send and stay.
- [ ] Inside the Mirth Connect Administrator navigate to **Dashboard** and press the **Refresh** button under *Dashboard Tasks**. If your request succeeded then no errors will appear and it will be forwarded to the database channel. Also the messages received count should be incremented by 1.
- [ ] Inside the redcap_mirth_client module's project navigate to the **Mirth Logs** page to view the request you just sent.

