### PR TITLE
Adding option to create users from site staff form

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -11,6 +11,7 @@ require_once 'includes/RxSender.php';
 use ExternalModules\AbstractExternalModule;
 use ExternalModules\ExternalModules;
 use Records;
+use RCView;
 use RedCapDB;
 use REDCap;
 use SendRx\RxSender;
@@ -24,7 +25,7 @@ class ExternalModule extends AbstractExternalModule {
     /**
      * @inheritdoc.
      */
-    function hook_data_entry_form_top($project_id, $record, $instrument, $event_id, $group_id) {
+    function hook_data_entry_form_top($project_id, $record = null, $instrument, $event_id, $group_id = null, $repeat_instance = 1) {
         // New PDF is generated based on pdf_is_updated flag.
         // Reset flag once PDF is generated to avoid duplicate generation of the same PDF.
         global $Proj;
@@ -33,6 +34,92 @@ class ExternalModule extends AbstractExternalModule {
             if ($Proj->metadata['send_rx_dag_id']['form_name'] == $instrument) {
                 // Hiding DAG ID field.
                 $this->includeJs('js/dag-id-field.js');
+            }
+            elseif ($Proj->metadata['send_rx_user_id']['form_name'] == $instrument) {
+                global $lang;
+
+                $this->includeJs('js/create-staff.js');
+                $this->setJsSetting('usernameValidateRegexElement', RCView::div(array(
+                    'id' => 'valregex-username',
+                    'datatype' => 'text',
+                    'label' => $lang['control_center_45'],
+                ), '/^([a-zA-Z0-9_\.\-\@])+$/'));
+                $this->setJsSetting('getUserProfileInfoUrl', $this->getUrl('includes/get_user_profile_info_ajax.php'));
+
+                // Creating artificial fields to make user able to create
+                // to account + profile directly from this form.
+                $base_field = $Proj->metadata['send_rx_user_id'];
+
+                $select_field_name = 'send_rx_new_user_opt';
+                $form_name = $base_field['form_name'];
+                $Proj->forms[$form_name]['fields'][$select_field_name] = $label;
+
+                $options = array(
+                    'existing' => 'Select an existing user',
+                    'new' => 'Create a new user account from scratch',
+                );
+
+                $enum = array();
+                foreach ($options as $key => $label) {
+                    $enum[] = $key . ', ' . $label;
+                }
+
+                // Adding select list field that asks user whether to select an
+                // existing user or create a new account.
+                $Proj->metadata[$select_field_name] = array(
+                    'field_name' => $select_field_name,
+                    'element_label' => '',
+                    'element_type' => 'radio',
+                    'element_enum' => implode(' \n', $enum),
+                    'misc' => '@DEFAULT="existing"',
+                ) + $base_field;
+
+                $base_field['misc'] = '';
+                $base_field['element_type'] = 'text';
+                $base_field['element_enum'] = '';
+                $base_field['element_preceding_header'] = '';
+                $base_field['field_order']++;
+
+                $fields = array(
+                    'id' => 'Username',
+                    'first_name' => 'First name',
+                    'last_name' => 'Last name',
+                    'email' => 'Email',
+                );
+
+                // Shifting position of existing fields to make room for the
+                // fake fields.
+                $count = count($fields) + 1;
+                foreach (array_keys($Proj->forms[$form_name]['fields']) as $field_name) {
+                    if ($Proj->metadata[$field_name]['field_order'] > $Proj->metadata[$select_field_name]['field_order']) {
+                        $Proj->metadata[$field_name]['field_order'] += $count;
+                    }
+                }
+
+                $Proj->metadata['send_rx_user_id']['field_order']++;
+                $Proj->metadata['send_rx_user_id']['element_preceding_header'] = '';
+
+                // Updating fields count.
+                $Proj->numFields += $count;
+
+                // Adding username, first name, last name and email fake fields.
+                foreach ($fields as $suffix => $label) {
+                    $field_name = 'send_rx_new_user_' . $suffix;
+                    $label = 'New user -- ' . $label;
+
+                    $base_field['field_name'] = $field_name;
+                    $base_field['element_label'] = $label;
+                    $base_field['field_order']++;
+
+                    $Proj->metadata[$field_name] = $base_field;
+                    $Proj->forms[$form_name]['fields'][$field_name] = $label;
+                }
+
+                // Adding email validation.
+                $Proj->metadata[$field_name]['element_validation_type'] = 'email';
+
+                // Re-sorting form fields.
+                uksort($Proj->forms[$form_name]['fields'], array($this, '_formFieldCmp'));
             }
 
             return;
@@ -144,7 +231,7 @@ class ExternalModule extends AbstractExternalModule {
             if ($sender->getPrescriberData()) {
                 // Generate PDF.
                 $sender->generatePDFFile();
-                send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_pdf_is_updated', '1', $repeat_instance);
+                send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_pdf_is_updated', '1');
                 echo '<div class="darkgreen" style="margin-bottom:30px;"><img src="' . APP_PATH_IMAGES . 'tick.png"> A new prescription PDF preview has been created.</div>';
             }
             else {
@@ -441,23 +528,48 @@ class ExternalModule extends AbstractExternalModule {
     /**
      * @inheritdoc.
      */
-    function hook_save_record($project_id, $record, $instrument, $event_id, $group_id, $survey_hash, $response_id) {
+    function hook_save_record($project_id, $record = null, $instrument, $event_id, $group_id = null, $survey_hash = null, $response_id = null, $repeat_instance = 1) {
         global $Proj;
 
         // Auto create a DAG in patients project when a new site is created.
         // Link this DAG Id to the site created.
         if ($config = send_rx_get_project_config($project_id, 'site')) {
-            if (!isset($Proj->metadata['send_rx_dag_id']) || $Proj->metadata['send_rx_dag_id']['form_name'] != $instrument) {
-                return;
+            if ($Proj->metadata['send_rx_dag_id']['form_name'] == $instrument) {
+                $data = send_rx_get_record_data($project_id, $record, $event_id);
+                if ($data['send_rx_dag_id']) {
+                    send_rx_rename_dag($config['target_project_id'], $data['send_rx_site_name'], $data['send_rx_dag_id']);
+                }
+                else {
+                    $group_id = send_rx_add_dag($config['target_project_id'], $data['send_rx_site_name']);
+                    send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_dag_id', $group_id);
+                }
             }
+            elseif ($Proj->metadata['send_rx_user_id']['form_name'] == $instrument) {
+                if (empty($_POST['send_rx_new_user_opt']) || $_POST['send_rx_new_user_opt'] != 'new') {
+                    return;
+                }
 
-            $data = send_rx_get_record_data($project_id, $record, $event_id);
-            if ($data['send_rx_dag_id']) {
-                send_rx_rename_dag($config['target_project_id'], $data['send_rx_site_name'], $data['send_rx_dag_id']);
-            }
-            else {
-                $group_id = send_rx_add_dag($config['target_project_id'], $data['send_rx_site_name']);
-                send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_dag_id', $group_id);
+                $values = array();
+                foreach (array('id', 'first_name', 'last_name', 'email') as $suffix) {
+                    if (empty($_POST['send_rx_new_user_' . $suffix])) {
+                        return;
+                    }
+
+                    $values['send_rx_user_' . $suffix] = trim(strip_tags(label_decode($_POST['send_rx_new_user_' . $suffix])));
+                }
+
+                $username = preg_replace('/[^a-z A-Z0-9_\.\-\@]/', '', $values['send_rx_user_id']);
+                if ($username != $values['send_rx_user_id']) {
+                    // Invalid username.
+                    return;
+                }
+
+                if (!UserProfile::createProfile($values)) {
+                    return;
+                }
+
+                send_rx_create_user($username, $values['send_rx_user_first_name'], $values['send_rx_user_last_name'], $values['send_rx_user_email']);
+                send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_user_id', $username, $repeat_instance);
             }
 
             return;
@@ -503,7 +615,7 @@ class ExternalModule extends AbstractExternalModule {
         // New PDF needs to be generated as changes are made to form after PDF is created.
         // Reset pdf_is_updated flag to generate new PDF.
         $field_name = 'send_rx_pdf_is_updated';
-        send_rx_save_record_field($project_id, $event_id, $record, $field_name, '0', $repeat_instance);
+        send_rx_save_record_field($project_id, $event_id, $record, $field_name, '0');
     }
 
     /**
@@ -536,5 +648,21 @@ class ExternalModule extends AbstractExternalModule {
      */
     protected function setJsSetting($key, $value) {
         echo '<script>sendRx.' . $key . ' = ' . json_encode($value) . ';</script>';
+    }
+
+    /**
+     * Auxiliary function to compare the order between two fields.
+     *
+     * @param string $a
+     *   Name of the field to be compared.
+     * @param string $b
+     *   Name of the field to compare with.
+     *
+     * @return
+     *   TRUE if $a comes first than $b, FALSE otherwise.
+     */
+    function _formFieldCmp($a, $b) {
+        global $Proj;
+        return $Proj->metadata[$a]['field_order'] >= $Proj->metadata[$b]['field_order'];
     }
 }

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ The steps below will walk you through a study research use case.
 
 ### Step 1: Making sure that user authentication is enabled
 Send Rx requires user authentication method to work, so if your REDCap does not have it, you may need to follow the steps below:
+
 1. Go to **Control Manager > Add Users (Table-based Only)**
-2. Add a new user that will be the new admin account (`site_admin` will be deprecated)
+2. Add a new user that will be the new admin account (since `site_admin` will become deprecated)
 3. Go to **Control Manager > Administrators & Acct Managers** and add the new user to the administrators list
 4. Go to **Control Manager > Security & Authentication**, select an authentication method of your choice (e.g. Table-based), and save
 5. Check your email inbox and look for a "REDCap access granted" email
@@ -63,29 +64,20 @@ Send Rx requires user authentication method to work, so if your REDCap does not 
 
 ## Sending your First Test Prescription
 
-### Step 1: Creating a few test users
-1. Go to **Control Manager > Add Users (Table-based Only)** and create a few test users.
-2. Go to **Control Manager > Browse Users** and click on **View Users**.
-3. For each account you created:
-  - Access its details page;
-  - Click on **Create user profile** button;
-  - Fill and submit the user profile information.
-
-### Step 2: Create a Site/Pharmacy
+### Step 1: Create a Site/Pharmacy
 1. On site project, go to **Add / Edit records** and then click on **Add new record**.
-2. Fill **Site Information** form step and go ahead to the next step
-3. On **Delivery methods step**, choose `Email` as the delivery type, then fill the email address you want to use in your test, and save.
-4. On **Site Staff** step, add the test users you created previously (make sure to add prescribers and at least one study coordinator), then click on **Save & Exit**
-5. On record home page, will might be able to see two buttons: **Rebuild staff permissions** and **Revoke staff permissions**
-6. Click on **Rebuild staff permissions** to grant permissions to your staff
+2. On **Site Information** form, fill out site name, then select `Email` as delivery type, then set the email address you want to use in your test, and finally save - making sure sure your form is set as *Complete*.
+4. On **Site Staff** step, select **Create a new user account from scratch**, fill out user information, make sure your form is set as *Complete*, then click on **Save & Go To Next Instance**
+5. Repeat the step above a few times - making sure to add at least one prescriber and one study coordinator - then click on **Save & Exit**
+6. You will be redirected to record home page, in which you should be able to see two buttons: **Rebuild staff permissions** and **Revoke staff permissions** (if both buttons are disabled, make sure all forms previously filled are set as *Complete*, i.e. they appear as green bullets)
+7. Click on **Rebuild staff permissions** to grant permissions to your staff
 
-### Step 3: Create a Prescription and Send it
-1. Log in as study coordinator.
+### Step 2: Create a Prescription and Send it
+1. Log in as study coordinator
 2. On patient project, go to **Add / Edit records** and then click on **Add new record**
-3. Complete all steps until the last step (**Review & Send Rx**).
-5. On review step, click on **Send and Stay**
-6. At **Messages History** block you should now see the notification contents you just sent.
-7. Check your email inbox.
+3. Fill out all forms until the last one - **Review & Send Rx** - then click on **Send and Stay**
+4. At **Messages History** block you should now see the notification contents you just sent
+5. Check your email inbox
 
 ## Customizing PDF and email messages
 

--- a/includes/get_user_profile_info_ajax.php
+++ b/includes/get_user_profile_info_ajax.php
@@ -1,0 +1,32 @@
+<?php
+
+use UserProfile\UserProfile;
+
+$response = array('success' => false, 'msg' => 'An error occurred');
+
+if (empty($_GET['username'])) {
+    $response['msg'] = 'Missing username.';
+    echo json_encode($response);
+    exit;
+}
+
+$profile = new UserProfile($_GET['username'], false);
+if (
+    !($profile_id = $profile->getProfileId()) ||
+    !($project_id = $profile->getProjectId()) ||
+    !($username_field = $profile->getUsernameField())
+) {
+    echo json_encode($response);
+    exit;
+}
+
+$project = new Project($project_id);
+echo json_encode(array(
+    'success' => true,
+    'data' => array(
+        'pid' => $project_id,
+        'id' => $profile_id,
+        'event_id' => $project->firstEventId,
+        'page' => $project->metadata[$username_field]['form_name'],
+    ),
+));

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -588,3 +588,99 @@ function send_rx_rename_dag($project_id, $group_name, $group_id) {
 
     db_query('UPDATE redcap_data_access_groups SET group_name = "' . $group_name . '" WHERE project_id = ' . $project_id . ' AND group_id = ' . $group_id);
 }
+
+/**
+ * Creates a basic user.
+ *
+ * @param string $username
+ *   The new username.
+ * @param string $firstname
+ *   The new user first name.
+ * @param string $lastname
+ *   The new user last name.
+ * @param string $email
+ *   The new user email address.
+ * @param bool $send_notification
+ *   Defines whether to send a notification to the user. Defaults to TRUE.
+ *
+ * @return bool
+ *   TRUE if success, FALSE otherwise.
+ */
+function send_rx_create_user($username, $firstname, $lastname, $email, $send_notification = true, $add_to_whitelist = true) {
+    if (User::getUserInfo($username)) {
+        // User already exists.
+        return false;
+    }
+
+    global $default_datetime_format, $default_number_format_decimal, $default_number_format_thousands_sep;
+
+    $db = new RedCapDB();
+    $sql = $db->saveUser(null, $username, $firstname, $lastname, $email,
+                         null, null, null, null, null, null, 0, generateRandomHash(8),
+                         $default_datetime_format, $default_number_format_decimal, $default_number_format_thousands_sep,
+                         1, null, null, '4_HOURS', '0', 0, 0, 0);
+
+    if (empty($sql)) {
+        return false;
+    }
+
+    // Log the new user
+    Logging::logEvent(implode(";\n", $sql), 'redcap_auth', 'MANAGE', $username, 'user = ' . $username, 'Create username');
+
+    if ($add_to_whitelist) {
+        // Adding user to whitelist, if whitelist is enabled.
+        $q = db_query('SELECT 1 FROM redcap_config WHERE field_name = "enable_user_whitelist" AND value = 1');
+        if (db_num_rows($q)) {
+            $sql = 'INSERT INTO redcap_user_whitelist VALUES ("' . db_real_escape_string($username) . '")';
+            if (!db_query($sql)) {
+                return false;
+            }
+
+            Logging::logEvent($sql, 'redcap_user_whitelist', 'MANAGE', '', '', 'Add user to whitelist');
+        }
+    }
+
+    if (!$send_notification) {
+        return true;
+    }
+
+    global $auth_meth;
+
+    switch ($auth_meth) {
+        case 'table':
+            global $lang, $project_contact_email;
+
+            $msg = new Message();
+            $msg->setTo($email);
+            $msg->setToName($firstname . ' ' . $lastname);
+            $msg->setFrom($project_contact_email);
+
+            // Set up the email subject.
+            $msg->setSubject('REDCap ' . $lang['control_center_101']);
+
+            // Get reset password link
+            $resetpasslink = Authentication::getPasswordResetLink($username);
+
+            $br = RCView::br();
+            $body = $lang['control_center_4488'] . ' "' . RCView::b($username) . '"' . $lang['period'] . ' ' .
+                    $lang['control_center_4486'] . $br . $br .
+                    RCView::a(array('href' => $resetpasslink), $lang['control_center_4487']);
+
+            // Set up email body.
+            $msg->setBody($body, true);
+
+            // Send the email.
+            return $msg->send();
+
+        case 'shibboleth':
+            $user_info = User::getUserInfo($username);
+            if ($code = User::setUserVerificationCode($user_info['ui_id'], 1)) {
+                // Send the email.
+                return User::sendUserVerificationCode($email, $code, 1, $username);
+            }
+
+            break;
+    }
+
+    return false;
+}

--- a/js/create-staff.js
+++ b/js/create-staff.js
@@ -1,0 +1,90 @@
+/**
+ * Branching logic according to user setup mode: existing or new.
+ */
+sendRx.doStaffBranching = function(value) {
+    var $newUserFields = $('input[name^="send_rx_new_user_"][type="text"]').parent().parent();
+    var $existingUserFields = $('select[name="send_rx_user_id"]').parent().parent().parent();
+
+    if (value == 'new') {
+        $newUserFields.show();
+        $existingUserFields.hide();
+    }
+    else if (value == 'existing') {
+        $existingUserFields.show();
+        $newUserFields.hide();
+    }
+    else {
+        $existingUserFields.hide();
+        $newUserFields.hide();
+    }
+};
+
+/**
+ * Refreshes "edit user profile" link according to the current selected user.
+ */
+sendRx.updateEditUserProfileLink = function(username = '') {
+    var $target = $('#edit-user-profile');
+
+    if (!username) {
+        $target.html('');
+        return;
+    }
+
+    $.get(sendRx.getUserProfileInfoUrl + '&username=' + username, function(data) {
+        if (!data.success) {
+            $target.html('');
+            return;
+        }
+
+        data = data.data;
+
+        var ret = [];
+        for (let d in data) {
+            ret.push(encodeURIComponent(d) + '=' + encodeURIComponent(data[d]));
+        }
+
+        var url = app_path_webroot + 'DataEntry/index.php?' + ret.join('&');
+        $('#edit-user-profile').html('<a class="smalllink" target="_blank" href="' + url + '">edit user profile</a>');
+    }, 'json');
+};
+
+$(document).ready(function() {
+    // Enforce username field validation.
+    $('#valregex_divs').append(sendRx.usernameValidateRegexElement);
+    $('input[name="send_rx_new_user_id"]').blur(function() {
+        redcap_validate(this, '', '', 'hard', 'username', 1);
+    });
+
+    $('tr[sq_id^="send_rx_new_user_"]').each(function() {
+        // Remove update history link, which does not work for fake fields.
+        $(this).find('label tr > td:last').remove();
+    });
+
+    // Do initial branching logic.
+    sendRx.doStaffBranching($('[name="send_rx_new_user_opt___radio"]:checked').val());
+
+    $('[name="send_rx_new_user_opt___radio"]').change(function() {
+        // Run branching logic when add user option is changed.
+        sendRx.doStaffBranching(this.value);
+    });
+
+    // Adding container for user profile edit link.
+    $('tr[sq_id="send_rx_user_id"] td:last').append('<div id="edit-user-profile" class="resetLinkParent"></div>');
+
+    var $userIdField = $('select[name="send_rx_user_id"]');
+    var username = $userIdField.val();
+
+    if (username) {
+        // If a profile exists, set "Select an existing user" option as
+        // default.
+        $('[name="send_rx_new_user_opt___radio"][value="existing"]').click();
+
+        // If a profile exists, create "edit user profile" link.
+        sendRx.updateEditUserProfileLink(username);
+    }
+
+    $userIdField.change(function() {
+        // Update user profile link when user field is changed.
+        sendRx.updateEditUserProfileLink($(this).val());
+    });
+});


### PR DESCRIPTION
This PR allows site admins to add staff members that do not exist yet in REDCap directly from Site Staff form.

Review steps:
- [x] Make sure to pull code from https://github.com/ctsit/redcap_user_profile/pull/9 to your User Profile module
- [x] Make sure your REDCap app has a configured "do not reply" email
- [x] Assuming you have a sites project set up, go to add new staff member form of a given site
- [x] Make sure you have 2 options of adding a staff member: "Select an existing user" and "Create a new user account from scratch"
- [x] Make sure "Selecting an existing user" works exactly as the usual/existing logic
- [ ] Make sure "Create a new user account from scratch" works as follows:
 - A new REDCap account is created, containing the entered username, first name, last name and email address
 - A new user profile is created for this account
 - If whitelist is enabled, the new user is included into it 
 - If current authentication method is "table based", the new user receives a password reset email
 - If current authentication method is "shibboleth", the new user receives an "email verification" notification
- [x] Make sure "edit user profile" link redirects to the correct user profile page, even when REDCap User field is changed