### PR TITLE
Fixing user creation bug under Shib

### DIFF
--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -635,13 +635,13 @@ function send_rx_create_user($username, $firstname, $lastname, $email, $send_not
         return false;
     }
 
-    global $default_datetime_format, $default_number_format_decimal, $default_number_format_thousands_sep;
+    global $default_datetime_format, $default_number_format_decimal, $default_number_format_thousands_sep, $auth_meth;
 
     $db = new RedCapDB();
     $sql = $db->saveUser(null, $username, $firstname, $lastname, $email,
                          null, null, null, null, null, null, 0, generateRandomHash(8),
                          $default_datetime_format, $default_number_format_decimal, $default_number_format_thousands_sep,
-                         1, null, null, '4_HOURS', '0', 0, 0, 0);
+                         1, null, null, '4_HOURS', '0', 0, $auth_meth == 'table' ? 0 : 1, 0);
 
     if (empty($sql)) {
         return false;
@@ -666,8 +666,6 @@ function send_rx_create_user($username, $firstname, $lastname, $email, $send_not
     if (!$send_notification) {
         return true;
     }
-
-    global $auth_meth;
 
     switch ($auth_meth) {
         case 'table':


### PR DESCRIPTION
Fixes #73.

This PR prevents password setup on account creation for Shib authenticated environments.

Please take a look at `isAaf` parameter of `RedCapDB`'s `saveUser()` method.

Although `isAaf` parameter was designed specifically for AAF authentication method, it fits like a glove for Shib, since the only thing this parameter does is to decide whether to setup a password for the new account (i.e. adding new entries to `redcap_auth` and `redcap_auth_history` db tables).