### PR TITLE
Preventing PDF links expiration on emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to the Send RX project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.2] - 2018-08-30
+### Changed
+- Prevent PDF links expiration on emails (Tiago Bember Simeao)
+
 
 ## [1.6.1] - 2018-08-09
 ### Changed

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -136,7 +136,7 @@ class ExternalModule extends AbstractExternalModule {
         }
 
         // Getting Rx sender to make sure we are in a patient project.
-        if (!$sender = RxSender::getSender($project_id, $event_id, $record)) {
+        if (!$sender = RxSender::getSender($project_id, $event_id, $record, $this)) {
             return;
         }
 
@@ -694,7 +694,7 @@ class ExternalModule extends AbstractExternalModule {
         }
 
         // Getting Rx sender to make sure we are in a patient project.
-        if (!$sender = RxSender::getSender($project_id, $event_id, $record)) {
+        if (!$sender = RxSender::getSender($project_id, $event_id, $record, $this)) {
             return;
         }
 

--- a/plugins/file_download.php
+++ b/plugins/file_download.php
@@ -1,0 +1,47 @@
+<?php
+
+// Making sure project is defined.
+if (!defined('PROJECT_ID')) {
+    return;
+}
+
+// Checking for required fields.
+foreach (['record', 'event_id', 'field_name'] as $key) {
+    if (empty($_GET[$key])) {
+        return;
+    }
+}
+
+global $Proj;
+
+// Making sure field and event are valid.
+if (
+    !isset($Proj->metadata[$_GET['field_name']]) ||
+    !isset($Proj->eventInfo[$_GET['event_id']]) ||
+    $Proj->metadata[$_GET['field_name']]['element_type'] != 'file'
+) {
+    return;
+}
+
+// Making sure record exists.
+if (!Records::recordExists(PROJECT_ID, $_GET['record'])) {
+    return;
+}
+
+$data = REDCap::getData(PROJECT_ID, 'array', $_GET['record'], $_GET['field_name'], $_GET['event_id']);
+if (empty($data[$_GET['record']][$_GET['event_id']][$_GET['field_name']])) {
+    return;
+}
+
+$file_id = intval($data[$_GET['record']][$_GET['event_id']][$_GET['field_name']]);
+$params = [
+    'pid' => PROJECT_ID,
+    'record' => $_GET['record'],
+    'event_id' => $_GET['event_id'],
+    'instance' => 1,
+    'field_name' => $_GET['field_name'],
+    'id' => $file_id,
+    'doc_id_hash' => Files::docIdHash($file_id),
+];
+
+redirect(APP_PATH_WEBROOT . 'DataEntry/file_download.php?' . http_build_query($params));


### PR DESCRIPTION
The goal of this PR is to make sure that PDF links always get the most recent prescription.

Review steps:
- [ ] Send a prescription to yourself and make sure you received an email from Send Rx
- [ ] Click on the prescription link and make sure you get a valid Rx PDF file
- [ ] Go back to your REDCap record, then access the prescriber form, and hit save
- [ ] Go to the Review & Send Rx form and make sure you see a message saying that a new prescription has been generated
- [ ] Without sending any further prescriptions, go back to the email you got previously
- [ ] Click on the prescription link again and make sure you get the most recent PDF file