### PR TITLE
Ensuring mPDF support to PHP 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "mpdf/mpdf": "v7.1.3"
+        "mpdf/mpdf": "^7.1",
+        "paragonie/random_compat": "<9.99"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "mpdf/mpdf": "^7.0.1"
+        "mpdf/mpdf": "v7.1.3"
     }
 }


### PR DESCRIPTION
Fixes #81.

More details about this solution: https://github.com/paragonie/random_compat#installing.

Review steps:
- [ ] Make sure your REDCap is running on a PHP 5 environment (PHP 7 is already supported)
- [ ] Update your `deploy/modules.json` in order to reference the fixed code (`tbembersimeao/develop`).
- [ ] Repack and redeploy REDCap via `redcap_deployment` tools
- [ ] Make sure PDF prescription generation is working again

Obs.: please disregard the first commit. It was a poor first approach.