### PR TITLE
Improving Send Rx event logging + status messages

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -239,8 +239,8 @@ class ExternalModule extends AbstractExternalModule {
             if ($error = !$sender->getPrescriberData()) {
                 REDCap::logEvent('Rx file generation failed', 'Prescriber information is not available.', '', $record, $event_id, $project_id);
             }
-            elseif ($error = !$sender->generatePDFFile()) {
-                $msg = send_rx_build_status_message('There was an error while creating the PDF prescription file. Check logs for further details.', true);
+            else {
+                $error = !$sender->generatePDFFile();
             }
 
             $msg = $error ? 'There was an error while creating the PDF prescription file. Check logs for further details.' : 'A new prescription PDF preview has been created.';

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -234,16 +234,18 @@ class ExternalModule extends AbstractExternalModule {
             $pdf_is_updated = $result['value'];
         }
 
-        // Checking if PDF needs to be generated.
+        // Generate PDF if needed.
         if (!$pdf_is_updated) {
-            if ($sender->getPrescriberData()) {
-                // Generate PDF.
-                $sender->generatePDFFile();
+            if ($sender->getPrescriberData() && $sender->generatePDFFile()) {
                 send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_pdf_is_updated', '1');
-                echo '<div class="darkgreen" style="margin-bottom:30px;"><img src="' . APP_PATH_IMAGES . 'tick.png"> A new prescription PDF preview has been created.</div>';
+
+                echo RCView::div(array(
+                    'class' => 'darkgreen',
+                    'style' => 'margin-bottom: 30px;',
+                ), RCView::img(array('src' => APP_PATH_IMAGES . 'tick.png')) . ' A new prescription PDF preview has been created.');
             }
             else {
-                $event_is_complete = false;
+                // TODO: error message.
             }
         }
 

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -650,6 +650,8 @@ class ExternalModule extends AbstractExternalModule {
                 else {
                     $group_id = send_rx_add_dag($config['target_project_id'], $data['send_rx_site_name']);
                     send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_dag_id', $group_id);
+
+                    $_SESSION['send_rx_status_message'] = send_rx_build_status_message('DAG "' . REDCap::escapeHtml($data['send_rx_site_name']) . '" was created on the patient project.');
                 }
             }
             elseif ($Proj->metadata['send_rx_user_id']['form_name'] == $instrument) {

--- a/ajax/assign_role_error_log.php
+++ b/ajax/assign_role_error_log.php
@@ -3,5 +3,9 @@
 global $isAjax;
 
 if ($isAjax && !empty($_POST['errors']) && defined('PROJECT_ID') && ($config = send_rx_get_project_config(PROJECT_ID, 'site'))) {
-    REDCap::logEvent('Roles assigning failed', json_encode($_POST['errors']), '', null, null, $config['target_project_id']);
+    $errors = json_encode($_POST['errors']);
+
+    foreach (array(PROJECT_ID => ' on patient project', $config['target_project_id'] => '') as $project_id => $suffix) {
+        REDCap::logEvent('Send Rx role assignments failed' . $suffix, $errors, '', null, null, $project_id);
+    }
 }

--- a/ajax/assign_role_error_log.php
+++ b/ajax/assign_role_error_log.php
@@ -1,0 +1,7 @@
+<?php
+
+global $isAjax;
+
+if ($isAjax && !empty($_POST['errors']) && defined('PROJECT_ID') && ($config = send_rx_get_project_config(PROJECT_ID, 'site'))) {
+    REDCap::logEvent('Roles assigning failed', json_encode($_POST['errors']), '', null, null, $config['target_project_id']);
+}

--- a/ajax/get_user_profile_info.php
+++ b/ajax/get_user_profile_info.php
@@ -2,6 +2,12 @@
 
 use UserProfile\UserProfile;
 
+global $isAjax;
+
+if (!$isAjax) {
+    exit;
+}
+
 $response = array('success' => false, 'msg' => 'An error occurred');
 
 if (empty($_GET['username'])) {

--- a/includes/RxSender.php
+++ b/includes/RxSender.php
@@ -411,10 +411,12 @@ class RxSender {
         $contents = send_rx_piping($contents, $data);
         $file_path = $this->generateTmpFilePath('pdf');
 
-        if (!send_rx_generate_pdf_file($contents, $file_path)) {
+        if (!send_rx_generate_pdf_file($contents, $file_path, $this->patientId, $this->patientEventId, $this->patientProjectId)) {
             return false;
         }
+
         if (!$file_id = send_rx_upload_file($file_path)) {
+            REDCap::logEvent('Rx file upload failed', '', '', $this->patientId, $this->patientEventId, $this->patientProjectId);
             return false;
         }
 
@@ -431,6 +433,7 @@ class RxSender {
         send_rx_save_record_field($this->patientProjectId, $this->patientEventId, $this->patientId, 'send_rx_pdf', $file_id);
         $this->patientData[$this->patientEventId]['send_rx_pdf'] = $file_id;
 
+        REDCap::logEvent('Rx file uploaded', 'File ID: ' . $file_id, '', $this->patientId, $this->patientEventId, $this->patientProjectId);
         return $file_id;
     }
 

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -180,7 +180,7 @@ function send_rx_generate_pdf_file($contents, $file_path, $record_id, $event_id,
         return false;
     }
 
-    REDCap::logEvent('New Rx file generated', $file_path, '', $record_id, $event_id, $project_id);
+    REDCap::logEvent('Rx file generated', $file_path, '', $record_id, $event_id, $project_id);
     return true;
 }
 

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -632,6 +632,31 @@ function send_rx_rename_dag($project_id, $group_name, $group_id) {
 }
 
 /**
+ * Gets DAG name.
+ *
+ * @param int $project_id
+ *   The project ID.
+ * @param int $group_id
+ *   The group ID.
+ *
+ * @return string|bool
+ *   The DAG name if exists, FALSE otherwise.
+ */
+function send_rx_get_dag_name($project_id, $group_id) {
+    if (intval($group_id) != $group_id) {
+        return false;
+    }
+
+    $q = db_query('SELECT group_name FROM redcap_data_access_groups WHERE project_id = ' . intval($project_id) . ' AND group_id = ' . $group_id);
+    if (!$q || !db_num_rows($q)) {
+        return false;
+    }
+
+    $dag = db_fetch_assoc($q);
+    return $dag['group_name'];
+}
+
+/**
  * Creates a basic user.
  *
  * @param string $username

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -5,9 +5,9 @@
  */
 
 include_once dirname(APP_PATH_DOCROOT) . '/vendor/autoload.php';
+
 use ExternalModules\ExternalModules;
 use UserProfile\UserProfile;
-use REDCap;
 
 /**
  * Gets Send RX config from project.
@@ -599,10 +599,14 @@ function send_rx_event_is_complete($project_id, $record, $event_id, $exclude = a
  */
 function send_rx_add_dag($project_id, $group_name) {
     $project_id = intval($project_id);
-    $group_name = db_real_escape_string($group_name);
+    $group_name = db_escape($group_name);
+    $sql = 'INSERT INTO redcap_data_access_groups (project_id, group_name) VALUES (' . $project_id . ', "' . $group_name . '")';
 
-    db_query('INSERT INTO redcap_data_access_groups (project_id, group_name) VALUES (' . $project_id . ', "' . $group_name . '")');
-    return db_insert_id();
+    db_query($sql);
+    $group_id = db_insert_id();
+
+    Logging::logEvent($sql, 'redcap_data_access_groups', 'MANAGE', $group_id, 'group_id = ' . $group_id, 'Create data access group', '', '', $project_id);
+    return $group_id;
 }
 
 /**
@@ -617,10 +621,13 @@ function send_rx_add_dag($project_id, $group_name) {
  */
 function send_rx_rename_dag($project_id, $group_name, $group_id) {
     $project_id = intval($project_id);
-    $group_name = db_real_escape_string($group_name);
     $group_id = intval($group_id);
+    $group_name = db_escape($group_name);
 
-    db_query('UPDATE redcap_data_access_groups SET group_name = "' . $group_name . '" WHERE project_id = ' . $project_id . ' AND group_id = ' . $group_id);
+    $sql = 'UPDATE redcap_data_access_groups SET group_name = "' . $group_name . '" WHERE project_id = ' . $project_id . ' AND group_id = ' . $group_id;
+    db_query($sql);
+
+    Logging::logEvent($sql, 'redcap_data_access_groups', 'MANAGE', $group_id, 'group_id = '. $group_id, 'Rename data access group', '', '', $project_id);
 }
 
 /**

--- a/includes/send_rx_functions.php
+++ b/includes/send_rx_functions.php
@@ -606,6 +606,8 @@ function send_rx_add_dag($project_id, $group_name) {
     $group_id = db_insert_id();
 
     _send_rx_log_dag_event('create', $sql, $group_id, $group_name, $project_id);
+
+    return $group_id;
 }
 
 /**

--- a/js/init.js
+++ b/js/init.js
@@ -1,3 +1,17 @@
 if (typeof sendRx === 'undefined') {
     var sendRx = {};
 }
+
+$(function() {
+    if (typeof sendRx.statusMessage !== 'undefined' && sendRx.statusMessage !== '') {
+        // Looking for the best spot for the status message.
+        var $header = $('#dataEntryTopOptions > div:last-child');
+
+        if ($header.length === 0) {
+            $('#subheader').after(sendRx.statusMessage);
+        }
+        else {
+            $header.append(sendRx.statusMessage);
+        }
+    }
+});

--- a/js/perm-buttons.js
+++ b/js/perm-buttons.js
@@ -1,11 +1,6 @@
 $(function() {
     var settings = sendRx.permsRebuild;
 
-    if (settings.msg !== '') {
-        // Showing success message.
-        $('#subheader').after(settings.msg);
-    }
-
     // Placing form into markup.
     $('#record_status_table').after(settings.form);
     var $form = $('#send_rx_perms');

--- a/js/perm-buttons.js
+++ b/js/perm-buttons.js
@@ -32,13 +32,19 @@ $(function() {
         $form.find('[name="operation"]').val(op);
 
         // Assigning/revoking roles.
-        sendRx.permsRebuild.assignRoles(Object.keys(roles), roles, $form);
+        sendRx.permsRebuild.assignRoles(Object.keys(roles), roles, $form, {});
     });
 });
 
-sendRx.permsRebuild.assignRoles = function(usersQueue, roles, $form) {
+sendRx.permsRebuild.assignRoles = function(usersQueue, roles, $form, errors) {
     if (!usersQueue.length) {
         // Submit the form when the last role is granted/revoked.
+        if (!$.isEmptyObject(errors)) {
+            // Log errors.
+            $.post(sendRx.permsRebuild.errorLogEndpointUrl, { errors: errors });
+            $form.find('[name="error_count"]').val(Object.keys(errors).length);
+        }
+
         $form.submit();
         return;
     }
@@ -47,7 +53,15 @@ sendRx.permsRebuild.assignRoles = function(usersQueue, roles, $form) {
     var userId = usersQueue.shift();
 
     // Calling user role assign endpoint.
-    $.post(sendRx.permsRebuild.url, { username: userId, role_id: roles[userId], notify_email_role: 0 }, function() {
-        sendRx.permsRebuild.assignRoles(usersQueue, roles, $form);
+    $.post(sendRx.permsRebuild.url, { username: userId, role_id: roles[userId], notify_email_role: 0 }, function(data) {
+        var $response = $('<div>' + data + '</div>');
+
+        if ($response.find('.userSaveMsg.darkgreen').length === 0) {
+            errors[userId] = roles[userId];
+        }
+    }).fail(function() {
+        errors[userId] = roles[userId];
+    }).always(function() {
+        sendRx.permsRebuild.assignRoles(usersQueue, roles, $form, errors);
     });
 }


### PR DESCRIPTION
Fixes #70.

New events logged on patient project:
- "Rx file generated"
- "Rx file generation failed" (displays mPDF error if available)
- "Rx file uploaded"
- "Rx file upload failed"
- "Send Rx role assignments failed on patient project" (displays list of failed assignments)

New status messages added on patient project:
- "There was an error while creating the PDF prescription file. Check logs for further details."

New events logged on site project
- "Send Rx role assignments failed" (triggered by site project, displays list of failed assignments)
- "Created external DAG" (displays DAG name and ID)
- "Renamed external DAG" (displays DAG name and ID)
- "User creation failed"
- Logs from https://github.com/ctsit/redcap_user_profile/pull/10

New status messages added on site project:
- "`<error_count>` role assignments failed. See logs for further details."
- "DAG `<dag_name>` was created on the patient project."
- "Invalid username." (when creating user account)
- "There was an error while creating the user. Check logs for further details."
