### PR TITLE
Making DAG ID field visible for admins

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -32,8 +32,10 @@ class ExternalModule extends AbstractExternalModule {
 
         if ($config = send_rx_get_project_config($project_id, 'site')) {
             if ($Proj->metadata['send_rx_dag_id']['form_name'] == $instrument) {
-                // Hiding DAG ID field.
-                $this->includeJs('js/dag-id-field.js');
+                if (!SUPER_USER && !ACCOUNT_MANAGER) {
+                    // Hiding DAG ID field.
+                    $Proj->metadata['send_rx_dag_id']['misc'] .= ' @HIDDEN';
+                }
             }
             elseif ($Proj->metadata['send_rx_user_id']['form_name'] == $instrument) {
                 global $lang;

--- a/js/dag-id-field.js
+++ b/js/dag-id-field.js
@@ -1,3 +1,0 @@
-$(document).ready(function() {
-    $('#send_rx_dag_id-tr').hide();
-});


### PR DESCRIPTION
Fixes #84.

Review steps:
- [ ] On site project, make sure you have a `send_rx_dag_id` field properly placed
- [ ] As global admin, go to new record page (on the first instrument), and make sure you see DAG ID field

Checking for regressions:
- [ ] Still on the form from the previous step, set a DAG value (it can be any value for testing purposes), click on "Save & Stay", and make sure the value has been properly saved
- [ ] Change DAG ID value, click on "Save & Stay" again, and make sure the value has been properly updated
- [ ] Erase DAG ID field value, click on "Save & Stay" again, and make sure a new DAG ID has been generated automatically
- [ ] As a non-admin, make sure you cannot see DAG ID field