### PR TITLE
Set send_rx_pdf_is_updated = 1 on successful PDF generation

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -245,6 +245,10 @@ class ExternalModule extends AbstractExternalModule {
                 $error = !$sender->generatePDFFile();
             }
 
+            // prevent regeneration of the PDF
+            $error ?: send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_pdf_is_updated', '1');
+
+            // log the appropriate message
             $msg = $error ? 'There was an error while creating the PDF prescription file. Check logs for further details.' : 'A new prescription PDF preview has been created.';
             $this->setJsSetting('statusMessage', send_rx_build_status_message($msg, $error));
         }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -245,9 +245,6 @@ class ExternalModule extends AbstractExternalModule {
                 $error = !$sender->generatePDFFile();
             }
 
-            // prevent regeneration of the PDF
-            $error ?: send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_pdf_is_updated', '1');
-
             // log the appropriate message
             $msg = $error ? 'There was an error while creating the PDF prescription file. Check logs for further details.' : 'A new prescription PDF preview has been created.';
             $this->setJsSetting('statusMessage', send_rx_build_status_message($msg, $error));

--- a/includes/RxSender.php
+++ b/includes/RxSender.php
@@ -434,6 +434,10 @@ class RxSender {
         $this->patientData[$this->patientEventId]['send_rx_pdf'] = $file_id;
 
         REDCap::logEvent('Rx file uploaded', 'File ID: ' . $file_id, '', $this->patientId, $this->patientEventId, $this->patientProjectId);
+
+        // prevent regeneration of the PDF
+        send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_pdf_is_updated', '1');
+
         return $file_id;
     }
 

--- a/includes/RxSender.php
+++ b/includes/RxSender.php
@@ -436,7 +436,7 @@ class RxSender {
         REDCap::logEvent('Rx file uploaded', 'File ID: ' . $file_id, '', $this->patientId, $this->patientEventId, $this->patientProjectId);
 
         // prevent regeneration of the PDF
-        send_rx_save_record_field($project_id, $event_id, $record, 'send_rx_pdf_is_updated', '1');
+        send_rx_save_record_field($this->patientProjectId, $this->patientEventId, $this->patientId, 'send_rx_pdf_is_updated', '1');
 
         return $file_id;
     }


### PR DESCRIPTION
This PR fixes issue #88. To test it, 

To reproduce the error, follow these steps:
- [ ] Configure a test environment with send_rx 1.7.1
- [ ] Pend a prescription in the _Prescription Form_
- [ ] Open the _Review & Send Prescription_ form. Note the status message 'A new prescription PDF preview has been created.' 
- [ ] Re-open the _Review & Send Prescription_ form. Note the status message 'A new prescription PDF preview has been created.' appears _again_.

To verify this PR follow these steps:
- [x] Re-open the _Review & Send Prescription_ form. Note the status message 'A new prescription PDF preview has been created.' appears one more time.
- [x] Look at the log and note the ID of the document just created. 
- [x] Re-open the _Review & Send Prescription_ form. Note the status message does not reappear.
- [x] Look at the log and note that no new document has been created. The previous log entry should still be at the top of the log. 