### PR TITLE
Fix for issue #90

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -278,7 +278,7 @@ class ExternalModule extends AbstractExternalModule {
     /**
      * @inheritdoc.
      */
-    function hook_every_page_before_render($project_id) {
+    function hook_every_page_before_render($project_id = null) {
         if (empty($project_id)) {
             return;
         }


### PR DESCRIPTION
The module crashes if the `project_id` is null. This is not the expected behavior. The `hook_every_page_before_render` handles the null case on its own.